### PR TITLE
Add "Ontology" as dataType

### DIFF
--- a/Attribute type possibilities.txt
+++ b/Attribute type possibilities.txt
@@ -17,6 +17,7 @@ SEEK Strain
 SEEK Sample
 SEEK Sample Multi
 Controlled Vocabulary
+Ontology
 URI
 DOI
 NCBI ID

--- a/templates/arrayexpress/source_plant_v1.2.0.json
+++ b/templates/arrayexpress/source_plant_v1.2.0.json
@@ -26,7 +26,7 @@
     "iri": "http://purl.obolibrary.org/obo/OBI_0100026",
     "name": "organism",
     "description": "A material entity that is an individual living system, such as animal, plant, bacteria or virus, that is capable of replicating or reproducing, growth and maintenance in the right environment. An organism may be unicellular or made up, like humans, of many billions of cells divided into specialized tissues and organs. E.g Drosophila melanogaster.",
-    "dataType": "Controlled Vocabulary",
+    "dataType": "Ontology",
     "required": true,
     "isaTag": "source_characteristic",
     "ontology": {
@@ -40,7 +40,7 @@
     "iri": "http://www.ebi.ac.uk/efo/EFO_0000635",
     "name": "organism part",
     "description": "The part of organism's anatomy or substance arising from an organism from which the biomaterial was derived, excludes cells. E.g. tissue, organ, system, sperm, blood or body location (arm).",
-    "dataType": "Controlled Vocabulary",
+    "dataType": "Ontology",
     "required": true,
     "isaTag": "source_characteristic",
     "ontology": {
@@ -54,7 +54,7 @@
     "iri": "http://www.ebi.ac.uk/efo/EFO_0000399",
     "name": "developmental stage",
     "description": "A developmental stage is spatiotemporal region encompassing some part of the life cycle of an organism, e.g. blastula stage",
-    "dataType": "Controlled Vocabulary",
+    "dataType": "Ontology",
     "required": true,
     "isaTag": "source_characteristic",
     "ontology": {
@@ -68,7 +68,7 @@
     "iri": "http://www.ebi.ac.uk/efo/EFO_0000246",
     "name": "age",
     "description": "A temporal measurement of the time period elapsed since an identifiable point in the life cycle of an organism. If a developmental stage is specified, the identifiable point would be the beginning of that stage. Otherwise the identifiable point must be specified such as planting (e.g. 3 days post planting).",
-    "dataType": "Controlled Vocabulary",
+    "dataType": "Ontology",
     "required": true,
     "isaTag": "source_characteristic",
     "ontology": {
@@ -82,7 +82,7 @@
     "iri": "http://www.ebi.ac.uk/efo/EFO_0000513",
     "name": "genotype",
     "description": "The total sum of the genetic information of an organism that is known and relevant to the experiment being performed, including chromosomal, plasmid, viral or other genetic material which has been introduced into the organism either prior to or during the experiment.",
-    "dataType": "Controlled Vocabulary",
+    "dataType": "Ontology",
     "required": true,
     "isaTag": "source_characteristic",
     "ontology": {
@@ -104,7 +104,7 @@
     "iri": "http://purl.obolibrary.org/obo/CL_0000010",
     "name": "cultured cell",
     "description": "A cell in vitro that is or has been maintained or propagated as part of a cell culture.",
-    "dataType": "Controlled Vocabulary",
+    "dataType": "Ontology",
     "required": false,
     "isaTag": "source_characteristic",
     "ontology": {
@@ -118,7 +118,7 @@
     "iri": "http://www.ebi.ac.uk/efo/EFO_0000324",
     "name": "cell type",
     "description": "A cell type is a distinct morphological or functional form of cell. Examples are epithelial, glial etc.",
-    "dataType": "Controlled Vocabulary",
+    "dataType": "Ontology",
     "required": false,
     "isaTag": "source_characteristic",
     "ontology": {
@@ -132,7 +132,7 @@
     "iri": "http://www.ebi.ac.uk/efo/EFO_0000352",
     "name": "clinical history",
     "description": "Is an information entity about the material's (i.e., the patient's) medical record as background information relevant to the experiment.",
-    "dataType": "Controlled Vocabulary",
+    "dataType": "Ontology",
     "required": false,
     "isaTag": "source_characteristic",
     "ontology": {
@@ -146,7 +146,7 @@
     "iri": "http://purl.obolibrary.org/obo/CHEBI_24431",
     "name": "chemical entity",
     "description": "A drug, solvent, chemical, etc., with a property that can be measured such as concentration. A molecular entity consisting of two or more chemical elements.",
-    "dataType": "Controlled Vocabulary",
+    "dataType": "Ontology",
     "required": false,
     "isaTag": "source_characteristic",
     "ontology": {
@@ -160,7 +160,7 @@
     "iri": "http://www.ebi.ac.uk/efo/EFO_0002755",
     "name": "diet",
     "description": "The customary allowance of food and drink taken by a person or an animal from day to day, particularly one especially planned to meet specific requirements of the individual, including or excluding certain items of food; a prescribed course of eating and drinking in which the amount and kind of food, as well as the times at which it is to be taken, are regulated for therapeutic purposes or selected with reference to a particular state of health. Regular course of eating and drinking adopted by a person or animal. This does not include DIET THERAPY, a specific diet prescribed in the treatment of a disease.",
-    "dataType": "Controlled Vocabulary",
+    "dataType": "Ontology",
     "required": false,
     "isaTag": "source_characteristic",
     "ontology": {
@@ -174,7 +174,7 @@
     "iri": "http://www.ebi.ac.uk/efo/EFO_0000408",
     "name": "disease",
     "description": "A disease is a disposition to undergo pathological processes that exists in an organism because of one or more disorders in that organism. [ OGMS:0000031 ]",
-    "dataType": "Controlled Vocabulary",
+    "dataType": "Ontology",
     "required": false,
     "isaTag": "source_characteristic",
     "ontology": {
@@ -188,7 +188,7 @@
     "iri": "http://www.ebi.ac.uk/efo/EFO_0000410",
     "name": "disease staging",
     "description": "The stage or progression of a disease in an organism. Includes pathological staging of cancers and other disease progression. E.g. Dukes C stage describing colon cancer.",
-    "dataType": "Controlled Vocabulary",
+    "dataType": "Ontology",
     "required": false,
     "isaTag": "source_characteristic",
     "ontology": {
@@ -210,7 +210,7 @@
     "iri": "http://www.ebi.ac.uk/efo/EFO_0000434",
     "name": "ecotype",
     "description": "A biotype resulting from selection in a particular habitat, e.g. the A. thaliana Ecotype Ler.",
-    "dataType": "Controlled Vocabulary",
+    "dataType": "Ontology",
     "required": false,
     "isaTag": "source_characteristic",
     "ontology": {
@@ -248,7 +248,7 @@
     "iri": "http://www.ebi.ac.uk/efo/EFO_0000510",
     "name": "genetic modification",
     "description": "A genetic modification of the genome of an organism which may occur naturally by spontaneous mutation, or be introduced by some experimental means. Examples of genetic modification include specification of a transgene or the gene knocked-out or details of transient transfection.",
-    "dataType": "Controlled Vocabulary",
+    "dataType": "Ontology",
     "required": false,
     "isaTag": "source_characteristic",
     "ontology": {
@@ -262,7 +262,7 @@
     "iri": "http://www.ebi.ac.uk/efo/EFO_0000523",
     "name": "growth condition",
     "description": "A role that a material entity can play which enables particular conditions used to grow organisms or parts of the organism. This includes isolated environments such as cultures and open environments such as field studies.",
-    "dataType": "Controlled Vocabulary",
+    "dataType": "Ontology",
     "required": false,
     "isaTag": "source_characteristic",
     "ontology": {
@@ -276,7 +276,7 @@
     "iri": "http://www.ebi.ac.uk/efo/EFO_0000541",
     "name": "immunoprecipitate",
     "description": "The precipitate antibody bound target molecules generated when precipitating an antigen out of a solution during the process of immunoprecipitation.",
-    "dataType": "Controlled Vocabulary",
+    "dataType": "Ontology",
     "required": false,
     "isaTag": "source_characteristic",
     "ontology": {
@@ -314,7 +314,7 @@
     "iri": "http://www.ebi.ac.uk/efo/EFO_0000546",
     "name": "injury",
     "description": "Damage inflicted on the body as the direct or indirect result of an external force, with or without disruption of structural continuity. [ NCIT:C3671 ]",
-    "dataType": "Controlled Vocabulary",
+    "dataType": "Ontology",
     "required": false,
     "isaTag": "source_characteristic",
     "ontology": {
@@ -344,7 +344,7 @@
     "iri": "http://www.ebi.ac.uk/efo/EFO_0000651",
     "name": "phenotype",
     "description": "The observable form taken by some character (or group of characters) in an individual or an organism, excluding pathology and disease. The detectable outward manifestations of a specific genotype.",
-    "dataType": "Controlled Vocabulary",
+    "dataType": "Ontology",
     "required": false,
     "isaTag": "source_characteristic",
     "ontology": {
@@ -366,7 +366,7 @@
     "iri": "http://www.ebi.ac.uk/efo/EFO_0000683",
     "name": "replicate",
     "description": "A role played by a a biological sample in the context of an experiment where the intent is that biological or technical variation is measured.",
-    "dataType": "Controlled Vocabulary",
+    "dataType": "Ontology",
     "required": false,
     "isaTag": "source_characteristic",
     "ontology": {
@@ -380,7 +380,7 @@
     "iri": "http://purl.obolibrary.org/obo/PATO_0000047",
     "name": "sex",
     "description": "The assemblage of physical properties or qualities by which male is distinguished from female; the physical difference between male and female; the distinguishing peculiarity of male or female. An organismal quality inhering in a bearer by virtue of the bearer's ability to undergo sexual reproduction in order to differentiate the individuals or types involved. Term applied to any organism able to undergo sexual reproduction in order to differentiate the individuals or types involved. Sexual reproduction is defined as the ability to exchange genetic material with the potential of recombinant progeny.",
-    "dataType": "Controlled Vocabulary",
+    "dataType": "Ontology",
     "required": false,
     "isaTag": "source_characteristic",
     "ontology": {
@@ -402,7 +402,7 @@
     "iri": "http://purl.obolibrary.org/obo/OBI_0001472",
     "name": "specimen with known storage state",
     "description": "A specimen for which it is known whether it has been subjected to storage of a specified type.",
-    "dataType": "Controlled Vocabulary",
+    "dataType": "Ontology",
     "required": false,
     "isaTag": "source_characteristic",
     "ontology": {
@@ -432,7 +432,7 @@
     "iri": "http://purl.obolibrary.org/obo/OBI_0600002",
     "name": "tumor grading",
     "description": "An assay that determines the grade (severity/stage) of a tumor sample, used in cancer biology to describe abnormalities/qualities of tumor cells or tissues. Values can be described by terms from NCI Thesaurus. Determination of the grade (severity/stage) of a tumor sample, used in cancer biology to describe abnormalities/qualities of tumor cells or tissues. Values can be described by terms from NCI Thesaurus.",
-    "dataType": "Controlled Vocabulary",
+    "dataType": "Ontology",
     "required": false,
     "isaTag": "source_characteristic",
     "ontology": {
@@ -446,7 +446,7 @@
     "iri": null,
     "name": "material type",
     "description": "Used as an attribute column following Source Name, Sample Name, Extract Name, or Labeled Extract Name. This column contains terms describing the type of each material, for examples: whole organism, organism part, cell, total RNA.",
-    "dataType": "Controlled Vocabulary",
+    "dataType": "Ontology",
     "required": true,
     "isaTag": "source_characteristic",
     "ontology": null,

--- a/templates/ena/nucleic acid sequencing_v1.2.0.json
+++ b/templates/ena/nucleic acid sequencing_v1.2.0.json
@@ -119,7 +119,24 @@
       "ontology": null,
       "CVList": null,
       "isaTag": "otherMaterial"
-    },      
+    },
+    {
+      "iri": null,
+      "name": "file type",
+      "description": "The run data file model.",
+      "dataType": "String",
+      "required": true,
+      "ontology": null,
+      "CVList": [
+        "bam",
+        "cram",
+        "fastq",
+        "oxfordnanopore_native",
+        "pacbio_hdf5",
+        "sff"
+        ],
+      "isaTag": "parameter_value"
+    },
     {
       "iri": null,
       "name": "Raw Data File",

--- a/templates/ena/sample_collection_plant_v1.0.0.json
+++ b/templates/ena/sample_collection_plant_v1.0.0.json
@@ -45,7 +45,7 @@
     "iri": null,
     "name": "sample material processing",
     "description": "Any processing applied to the sample during or after retrieving the sample from environment. This field accepts OBI, for a browser of OBI (v 2013-10-25) terms please see http://purl.bioontology.org/ontology/OBI",
-    "dataType": "string",
+    "dataType": "Ontology",
     "required": false,
     "ontology": {
       "name": "OBI",

--- a/templates/ena/sample_collection_plant_v1.0.0.json
+++ b/templates/ena/sample_collection_plant_v1.0.0.json
@@ -26,7 +26,7 @@
     "iri": null,
     "name": "sample collection",
     "description": "type of assay or experimental step performed.",
-    "dataType": "string",
+    "dataType": "String",
     "required": true,
     "ontology": null,    
     "CVList": null,//SOPtittle
@@ -36,7 +36,7 @@
     "iri": null,
     "name": "sample collection device or method",
     "description": "The method or deviced employed for collecting the sample",
-    "dataType": "string",
+    "dataType": "String",
     "required": false,
     "ontology": null,
     "isaTag": "parameter_value"    
@@ -58,7 +58,7 @@
     "iri": null,
     "name": "amount or size of sample collected",
     "description": "Amount or size of sample (volume, mass or area) that was collected",
-    "dataType": "(0|((0\\.)|([1-9][0-9]*\\.?))[0-9]*)([Ee][+-]?[0-9]+)?",
+    "dataType": "String", // original Regex "(0|((0\\.)|([1-9][0-9]*\\.?))[0-9]*)([Ee][+-]?[0-9]+)?",
     "required": false,
     "ontology": null,
     "isaTag": "parameter_value"    
@@ -67,7 +67,7 @@
     "iri": null,
     "name": "sample storage duration",
     "description": "duration for which sample was stored",
-    "dataType": "(0|((0\\.)|([1-9][0-9]*\\.?))[0-9]*)([Ee][+-]?[0-9]+)?",
+    "dataType": "String", // original Regex "(0|((0\\.)|([1-9][0-9]*\\.?))[0-9]*)([Ee][+-]?[0-9]+)?",
     "required": false,
     "ontology": null,
     "isaTag": "parameter_value"    
@@ -76,7 +76,7 @@
     "iri": null,
     "name": "sample storage temperature",
     "description": "temperature at which sample was stored, e.g. -80",
-    "dataType": "[+-]?(0|((0\\.)|([1-9][0-9]*\\.?))[0-9]*)([Ee][+-]?[0-9]+)?",
+    "dataType": "String", // original Regex "[+-]?(0|((0\\.)|([1-9][0-9]*\\.?))[0-9]*)([Ee][+-]?[0-9]+)?",
     "required": false,
     "ontology": null,
     "isaTag": "parameter_value"    
@@ -85,7 +85,7 @@
     "iri": null,
     "name": "sample storage location",
     "description": "location at which sample was stored, usually name of a specific freezer/room",
-    "dataType": "string",
+    "dataType": "String",
     "required": false,
     "ontology": null,
     "isaTag": "parameter_value"    
@@ -94,7 +94,7 @@
     "iri": null,
     "name": "sampling time point",
     "description": "",
-    "dataType": "string",
+    "dataType": "String",
     "required": false,
     "ontology": null,
     "isaTag": "parameter_value"    

--- a/templates/ena/source_plant_v1.0.0.json
+++ b/templates/ena/source_plant_v1.0.0.json
@@ -448,7 +448,7 @@
     "iri": null,
     "name": "environment (biome)",
     "description": "Biomes are defined based on factors such as plant structures, leaf types, plant spacing, and other factors like climate. Biome should be treated as the descriptor of the broad ecological context of a sample. Examples include: desert, taiga, deciduous woodland, or coral reef. EnvO (v 2013-06-14) terms can be found via the link: www.environmentontology.org/Browse-EnvO",
-    "dataType": "String",
+    "dataType": "Ontology",
     "required": false,
     "ontology": {
       "name": "ENVO",
@@ -463,12 +463,7 @@
     "description": "Environmental feature level includes geographic environmental features. Compared to biome, feature is a descriptor of the more local environment. Examples include: harbor, cliff, or lake. EnvO (v 2013-06-14) terms can be found via the link: www.environmentontology.org/Browse-EnvO",
     "dataType": "String",
     "required": false,
-    "ontology": {
-      "name": "ENVO",
-      "version": "",
-      "description": "Environment Ontology",
-      "rootTermURI": ""},
-      "isaTag": "source_characteristic"
+    "isaTag": "source_characteristic"
   },
   {
     "iri": null,
@@ -509,7 +504,7 @@
     "iri": null,
     "name": "plant structure",
     "description": "name of plant structure that the sample was obtained from; for Plant Ontology (PO) terms see http://purl.bioontology.org/ontology/PO, e.g. petiole epidermis (PO_0000051); if an individual flower is sampled the sex of it can be recorded here",
-    "dataType": "String",
+    "dataType": "Ontology",
     "required": true,    
     "ontology": {
       "name": "PO",
@@ -522,7 +517,7 @@
     "iri": null,
     "name": "plant developmental stage",
     "description": "developmental stage at the time of sample collection; for Plant Ontology (PO) (v 20) terms, see http://purl.bioontology.org/ontology/PO, e.g. hypocotyl emergence stage (PO_0007043)",
-    "dataType": "String",
+    "dataType": "Ontology",
     "required": true,
     "ontology": {
       "name": "PO",


### PR DESCRIPTION
Exchanged `Controlled Vocabulary` for `Ontology` as `dataType` for Attributes that have ontology terms as expected values.
Also commented out regex from `dataType` and substitute it with `"String"` in `sample_collection_plant_v1.0.0.json`.